### PR TITLE
fix: remove divider images from other pages headers

### DIFF
--- a/dataprotection.html
+++ b/dataprotection.html
@@ -13,19 +13,6 @@
   <body>
     <header>
       <img src="assets/2020.svg" alt="Ruby Unconf Logo" class="main-logo" />
-
-      <ul class="flying-circus">
-        <li><img src="assets/sticker/01.png" /></li>
-        <li><img src="assets/sticker/02.png" /></li>
-        <li><img src="assets/sticker/03.png" /></li>
-        <li><img src="assets/sticker/14.png" /></li>
-        <li><img src="assets/sticker/04.png" /></li>
-        <li><img src="assets/sticker/06.png" /></li>
-        <li><img src="assets/sticker/07.png" /></li>
-        <li><img src="assets/sticker/08.png" /></li>
-        <li><img src="assets/sticker/12.png" /></li>
-        <li><img src="assets/sticker/10.png" /></li>
-      </ul>
     </header>
 
     <nav>

--- a/imprint.html
+++ b/imprint.html
@@ -13,19 +13,6 @@
   <body>
     <header>
       <img src="assets/2020.svg" alt="Ruby Unconf Logo" class="main-logo" />
-
-      <ul class="flying-circus">
-        <li><img src="assets/sticker/01.png" /></li>
-        <li><img src="assets/sticker/02.png" /></li>
-        <li><img src="assets/sticker/03.png" /></li>
-        <li><img src="assets/sticker/14.png" /></li>
-        <li><img src="assets/sticker/04.png" /></li>
-        <li><img src="assets/sticker/06.png" /></li>
-        <li><img src="assets/sticker/07.png" /></li>
-        <li><img src="assets/sticker/08.png" /></li>
-        <li><img src="assets/sticker/12.png" /></li>
-        <li><img src="assets/sticker/10.png" /></li>
-      </ul>
     </header>
 
     <nav>


### PR DESCRIPTION
remove divider images from dataprotection and imprint pages (leftovers from an older version)